### PR TITLE
Allow if and while blocks without parentheses

### DIFF
--- a/pylo.py
+++ b/pylo.py
@@ -309,9 +309,12 @@ class Parser:
 
     def if_stmt(self):
         self.eat('ID')  # if
-        self.eat('LPAREN')
-        condition = self.expr()
-        self.eat('RPAREN')
+        if self.current() and self.current().type == 'LPAREN':
+            self.eat('LPAREN')
+            condition = self.expr()
+            self.eat('RPAREN')
+        else:
+            condition = self.expr()
         then_block = self.block()
         else_block = None
         if self.current() and self.current().type == 'ID' and self.current().value == 'else':
@@ -332,9 +335,12 @@ class Parser:
 
     def while_stmt(self):
         self.eat('ID')  # while
-        self.eat('LPAREN')
-        condition = self.expr()
-        self.eat('RPAREN')
+        if self.current() and self.current().type == 'LPAREN':
+            self.eat('LPAREN')
+            condition = self.expr()
+            self.eat('RPAREN')
+        else:
+            condition = self.expr()
         body = self.block()
         return WhileStmt(condition, body)
 


### PR DESCRIPTION
## Summary
- allow `if` and `while` statements without parentheses around their conditions

## Testing
- `python3 -m py_compile pylo.py`
- `python3 pylo.py examples/if.pylo`
- `python3 pylo.py examples/while.pylo`


------
https://chatgpt.com/codex/tasks/task_e_6844069077f083338bfa4be419be6984